### PR TITLE
Higher-order effects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "vendor/semilattices"]
 	path = vendor/semilattices
 	url = https://github.com/robrix/semilattices.git
+[submodule "vendor/higher-order-effects"]
+	path = vendor/higher-order-effects
+	url = https://github.com/robrix/higher-order-effects.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "vendor/semirings-modules"]
 	path = vendor/semirings-modules
 	url = https://github.com/robrix/semirings-modules.git
-[submodule "vendor/effects"]
-	path = vendor/effects
-	url = https://github.com/joshvera/effects.git
 [submodule "vendor/semilattices"]
 	path = vendor/semilattices
 	url = https://github.com/robrix/semilattices.git

--- a/Manifold.cabal
+++ b/Manifold.cabal
@@ -51,8 +51,8 @@ library
   build-depends:       base >=4.11 && <4.12
                      , bytestring
                      , containers
-                     , effects
                      , haskeline
+                     , higher-order-effects
                      , indentation-trifecta
                      , optparse-applicative
                      , parsers

--- a/src/Manifold/Abstract/Address/Monovariant.hs
+++ b/src/Manifold/Abstract/Address/Monovariant.hs
@@ -61,13 +61,13 @@ runAllocator :: ( Member NonDet sig
                 , Ord value
                 , Carrier sig m
                 )
-             => Evaluator Monovariant value (AllocatorC value (Evaluator Monovariant value m)) a
+             => Evaluator Monovariant value (AllocatorC (Evaluator Monovariant value m)) a
              -> Evaluator Monovariant value m a
 runAllocator = runAllocatorC . interpret . runEvaluator
 
-newtype AllocatorC value m a = AllocatorC { runAllocatorC :: m a }
+newtype AllocatorC m a = AllocatorC { runAllocatorC :: m a }
 
-instance (Alternative m, Carrier sig m, Ord value, Monad m) => Carrier (Allocator Monovariant value :+: sig) (AllocatorC value m) where
+instance (Member NonDet sig, Carrier sig m, Ord value) => Carrier (Allocator Monovariant value :+: sig) (AllocatorC (Evaluator Monovariant value m)) where
   gen = AllocatorC . gen
   alg = algA \/ (AllocatorC . alg . handlePure runAllocatorC)
     where algA (Alloc name k)            = k (Monovariant name)

--- a/src/Manifold/Abstract/Evaluator.hs
+++ b/src/Manifold/Abstract/Evaluator.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, GeneralizedNewtypeDeriving, StandaloneDeriving #-}
+{-# LANGUAGE DataKinds, FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, StandaloneDeriving, UndecidableInstances #-}
 module Manifold.Abstract.Evaluator
 ( Evaluator(..)
 , Alternative(..)
@@ -6,14 +6,15 @@ module Manifold.Abstract.Evaluator
 ) where
 
 import Control.Applicative
-import Control.Monad.Effect as X
-import Control.Monad.Effect.Fresh as X
-import Control.Monad.Effect.NonDet as X
-import Control.Monad.Effect.Reader as X
-import Control.Monad.Effect.Resumable as X
-import Control.Monad.Effect.State as X
+import Control.Effect as X
 
-newtype Evaluator address value effects a = Evaluator { runEvaluator :: Eff effects a }
-  deriving (Applicative, Effectful, Functor, Monad)
+newtype Evaluator address value carrier a = Evaluator { runEvaluator :: Eff carrier a }
+  deriving (Applicative, Functor, Monad)
 
-deriving instance Member NonDet effects => Alternative (Evaluator address value effects)
+deriving instance (Member NonDet sig, Carrier sig carrier) => Alternative (Evaluator address value carrier)
+
+instance Carrier sig carrier => Carrier sig (Evaluator address value carrier) where
+  gen = pure
+  alg op = Evaluator (alg (handlePure runEvaluator op))
+
+instance (Carrier sig carrier, Effect sig) => Effectful sig (Evaluator address value carrier)

--- a/src/Manifold/Abstract/Store.hs
+++ b/src/Manifold/Abstract/Store.hs
@@ -63,7 +63,7 @@ runStore :: Effectful sig m => Evaluator address value (StateC (Store address va
 runStore = runState lowerBound . runEvaluator
 
 data StoreError address value result where
-  Unallocated :: address -> StoreError address value (Set.Set value)
+  Unallocated   :: address -> StoreError address value (Set.Set value)
   Uninitialized :: address -> StoreError address value value
 
 instance Pretty address => Pretty1 (StoreError address value) where

--- a/src/Manifold/Eval.hs
+++ b/src/Manifold/Eval.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, GADTs, KindSignatures, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, PolyKinds, TypeOperators, UndecidableInstances #-}
 module Manifold.Eval where
 
-import Control.Monad.Effect.Internal hiding (apply)
 import qualified Data.Set as Set
 import Manifold.Abstract.Env
 import Manifold.Abstract.Evaluator
@@ -14,62 +13,78 @@ import Manifold.Term as Term
 import Manifold.Term.Elim
 import Manifold.Term.Intro
 
-runEval :: ( Member (Allocator address value) effects
-           , Member (Data value) effects
-           , Member (Env address) effects
-           , Member (Function value) effects
-           , Member (Resumable (EnvError address)) effects
-           , Member (Resumable (StoreError address value)) effects
-           , Member (State (Store address value)) effects
+runEval :: ( Member (Allocator address value) sig
+           , Member (Data value) sig
+           , Member (Env address) sig
+           , Member (Function value) sig
+           , Member (Resumable (EnvError address)) sig
+           , Member (Resumable (StoreError address value)) sig
+           , Member (State (Store address value)) sig
            , Ord address
            , Ord value
-           , PureEffects effects
+           , Carrier sig m
            )
-        => Evaluator address value (Eval value ': effects) a
-        -> Evaluator address value effects a
-runEval = go . lowerEff
-  where go (Return a) = pure a
-        go (Effect (Eval (Term term)) k) = runEval $ Evaluator . k =<< case term of
-          Var name -> lookupEnv name >>= deref
-          Intro i -> case i of
-            Abs var body -> do
-              let fvs = Set.delete (name var) (freeVariables body)
-              env <- close fvs
-              lambda (name var) (foldr (\ (v ::: addr) -> v .= addr) (eval body) env)
-            Data c as -> traverse eval as >>= construct c
-          Elim e -> case e of
-            App f a -> do
-              f' <- eval f
-              a' <- eval a
-              f' `apply` a'
-            Case s bs -> do
-              s' <- eval s
-              match <- foldr (\ (pattern, branch) rest -> do
-                res <- match s' pattern (Just <$> eval branch)
-                maybe rest (pure . Just) res) (pure Nothing) bs
-              maybe (error "non-exhaustive pattern match, should have been caught by typechecker") pure match
-        go (Other u k) = liftHandler runEval u (Evaluator . k)
+        => Evaluator address value (EvalC (Evaluator address value m)) a
+        -> Evaluator address value m a
+runEval = runEvalC . interpret . runEvaluator
 
-        match _ (Pattern Wildcard) next = next
-        match s (Pattern (Variable name)) next = do
-          address <- alloc name
-          assign address s
-          name .= address $ next
-        match s (Pattern (Constructor c' ps)) next = do
-          (c, vs) <- deconstruct s
-          if c == c' && length vs == length ps then
-            foldr (uncurry match) next (zip vs ps)
-          else
-            pure Nothing
+newtype EvalC m a = EvalC { runEvalC :: m a }
+
+instance ( Member (Allocator address value) sig
+         , Member (Data value) sig
+         , Member (Env address) sig
+         , Member (Function value) sig
+         , Member (Resumable (EnvError address)) sig
+         , Member (Resumable (StoreError address value)) sig
+         , Member (State (Store address value)) sig
+         , Ord address
+         , Ord value
+         , Carrier sig m
+         )
+      => Carrier (Eval value :+: sig) (EvalC (Evaluator address value m)) where
+  gen = EvalC . gen
+  alg = algE \/ (EvalC . alg . handlePure runEvalC)
+    where algE (Eval (Term term) k) = EvalC $ runEvalC . k =<< runEval (case term of
+            Var name -> lookupEnv name >>= deref
+            Intro i -> case i of
+              Abs var body -> do
+                let fvs = Set.delete (name var) (freeVariables body)
+                env <- close fvs
+                lambda (name var) (foldr (\ (v ::: addr) -> v .= addr) (eval body) env)
+              Data c as -> traverse eval as >>= construct c
+            Elim e -> case e of
+              App f a -> do
+                f' <- eval f
+                a' <- eval a
+                f' `apply` a'
+              Case s bs -> do
+                s' <- eval s
+                match <- foldr (\ (pattern, branch) rest -> do
+                  res <- match s' pattern (Just <$> eval branch)
+                  maybe rest (pure . Just) res) (pure Nothing) bs
+                maybe (error "non-exhaustive pattern match, should have been caught by typechecker") pure match)
+          match _ (Pattern Wildcard) next = next
+          match s (Pattern (Variable name)) next = do
+            address <- alloc name
+            assign address s
+            name .= address $ next
+          match s (Pattern (Constructor c' ps)) next = do
+            (c, vs) <- deconstruct s
+            if c == c' && length vs == length ps then
+              foldr (uncurry match) next (zip vs ps)
+            else
+              pure Nothing
 
 
-eval :: Member (Eval value) effects => Term Name -> Evaluator address value effects value
-eval = send . Eval
+eval :: (Member (Eval value) sig, Carrier sig m) => Term Name -> Evaluator address value m value
+eval = send . flip Eval gen
 
-data Eval value (m :: * -> *) result where
-  Eval :: Term Name -> Eval value m value
+data Eval value m k
+  = Eval (Term Name) (value -> k)
+  deriving (Functor)
 
 
-instance PureEffect (Eval value)
+instance HFunctor (Eval value) where
+  hfmap _ (Eval term k) = Eval term k
 instance Effect (Eval value) where
-  handleState c dist (Request (Eval term) k) = Request (Eval term) (dist . (<$ c) . k)
+  handle state handler (Eval term k) = Eval term (handler . (<$ state) . k)

--- a/src/Manifold/Pretty.hs
+++ b/src/Manifold/Pretty.hs
@@ -11,7 +11,7 @@ module Manifold.Pretty
 , putDoc
 ) where
 
-import Control.Monad.Effect
+import Control.Effect (SomeError(..))
 import Data.Text.Prettyprint.Doc as Doc hiding (Pretty(..))
 import qualified Data.Text.Prettyprint.Doc as Doc
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Doc
@@ -62,9 +62,8 @@ instance Pretty a => Pretty [a] where
 
 instance Pretty Int
 
-instance Pretty1 exc => Pretty (SomeExc exc) where
-  prettyPrec d (SomeExc exc) = liftPrettyPrec (const (const mempty)) d exc
-
+instance Pretty1 err => Pretty (SomeError err) where
+  prettyPrec d (SomeError err) = liftPrettyPrec (const (const mempty)) d err
 
 instance Pretty1 [] where
   liftPrettyPrec pp _ = list . map (pp 0)

--- a/src/Manifold/Proof/Checking.hs
+++ b/src/Manifold/Proof/Checking.hs
@@ -1,11 +1,7 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, GADTs, KindSignatures, TypeApplications, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, PolyKinds, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Manifold.Proof.Checking where
 
-import Control.Monad.Effect
-import Control.Monad.Effect.Fresh
-import Control.Monad.Effect.Internal hiding (apply)
-import Control.Monad.Effect.Reader
-import Control.Monad.Effect.State
+import Control.Effect
 import Data.Foldable (foldl')
 import Data.Semiring (Semiring(..), Unital(..), zero)
 import Data.Semilattice.Lower
@@ -27,59 +23,62 @@ import Manifold.Type hiding (Var, Elim, Intro)
 import Manifold.Type.Intro
 import Manifold.Unification
 
-checkModule :: ( Effects effects
+checkModule :: ( Carrier sig m
+               , Effect sig
                , Eq usage
-               , Member (Exc (Error (Annotated usage))) effects
-               , Member (Reader (ModuleTable Name (Term Name))) effects
-               , Member (State (ModuleTable (Annotated usage) (Term Name))) effects
+               , Member (Error (ProofError (Annotated usage))) sig
+               , Member (Reader (ModuleTable Name (Term Name))) sig
+               , Member (State (ModuleTable (Annotated usage) (Term Name))) sig
                , Monoid usage
                , Unital usage
                )
             => Module Name (Term Name)
-            -> Proof usage effects (Module (Annotated usage) (Term Name))
+            -> Proof usage m (Module (Annotated usage) (Term Name))
 checkModule m = lookupEvaluated (moduleName m) >>= maybe (cacheModule m) pure
 
-cacheModule :: ( Effects effects
+cacheModule :: ( Carrier sig m
+               , Effect sig
                , Eq usage
-               , Member (Exc (Error (Annotated usage))) effects
-               , Member (Reader (ModuleTable Name (Term Name))) effects
-               , Member (State (ModuleTable (Annotated usage) (Term Name))) effects
+               , Member (Error (ProofError (Annotated usage))) sig
+               , Member (Reader (ModuleTable Name (Term Name))) sig
+               , Member (State (ModuleTable (Annotated usage) (Term Name))) sig
                , Monoid usage
                , Unital usage
                )
             => Module Name (Term Name)
-            -> Proof usage effects (Module (Annotated usage) (Term Name))
+            -> Proof usage m (Module (Annotated usage) (Term Name))
 cacheModule (Module name imports decls) = do
   cacheEvaluated (Module name imports [])
   imports' <- traverse (\ name -> lookupUnevaluated name >>= maybe (unknownModule name) checkModule) imports
-  decls' <- runFresh 0 (runContext (runIsType (foldr (>-) (foldr combine (pure []) decls) (imports' >>= moduleExports))))
+  decls' <- runFresh (runProof (runContext (runIsType (foldr (>-) (foldr combine (pure []) decls) (imports' >>= moduleExports)))))
   let m = Module name imports decls'
   m <$ cacheEvaluated m
   where combine decl rest = do
           decl' <- checkDeclaration decl
           foldr (>-) ((decl' :) <$> rest) (declarationSignatures decl')
 
-lookupUnevaluated :: Member (Reader (ModuleTable Name (Term Name))) effects => Name -> Proof usage effects (Maybe (Module Name (Term Name)))
+lookupUnevaluated :: (Member (Reader (ModuleTable Name (Term Name))) sig, Carrier sig m) => Name -> Proof usage m (Maybe (Module Name (Term Name)))
 lookupUnevaluated name = asks (Module.lookup name)
 
-lookupEvaluated :: Member (State (ModuleTable (Annotated usage) (Term Name))) effects => Name -> Proof usage effects (Maybe (Module (Annotated usage) (Term Name)))
+lookupEvaluated :: (Member (State (ModuleTable (Annotated usage) (Term Name))) sig, Carrier sig m) => Name -> Proof usage m (Maybe (Module (Annotated usage) (Term Name)))
 lookupEvaluated name = gets (Module.lookup name)
 
-cacheEvaluated :: Member (State (ModuleTable (Annotated usage) (Term Name))) effects => Module (Annotated usage) (Term Name) -> Proof usage effects ()
-cacheEvaluated = modify' . insert
+cacheEvaluated :: (Member (State (ModuleTable (Annotated usage) (Term Name))) sig, Carrier sig m) => Module (Annotated usage) (Term Name) -> Proof usage m ()
+cacheEvaluated = modify . insert
 
 
-checkDeclaration :: ( Effects effects
+checkDeclaration :: ( Carrier sig m
+                    , Effect sig
                     , Eq usage
-                    , Member (Exc (Error (Annotated usage))) effects
-                    , Member Fresh effects
-                    , Member (IsType usage) effects
-                    , Member (Reader (Context (Constraint (Annotated usage) (Type (Annotated usage))))) effects
+                    , Member (Error (ProofError (Annotated usage))) sig
+                    , Member Fresh sig
+                    , Member (IsType usage) sig
+                    , Member (Reader (Context (Constraint (Annotated usage) (Type (Annotated usage))))) sig
                     , Monoid usage
                     , Unital usage
                     )
                  => Declaration Name (Term Name)
-                 -> Proof usage effects (Declaration (Annotated usage) (Term Name))
+                 -> Proof usage m (Declaration (Annotated usage) (Term Name))
 checkDeclaration (Binding (name ::: ty) term) = do
   ty' <- isType ty
   let annotated = Annotated name one
@@ -93,71 +92,87 @@ checkDeclaration (Datatype (name ::: ty) constructors) = do
   where checkConstructor (name ::: ty) = (Annotated name zero :::) <$> isType ty
 
 runCheck :: ( Eq usage
-            , Member (Exc (Error (Annotated usage))) effects
-            , Member Fresh effects
-            , Member (Reader usage) effects
-            , Member (Reader (Context (Constraint (Annotated usage) (Type (Annotated usage))))) effects
-            , Member (State (Substitution (Type (Annotated usage)))) effects
-            , Member (Unify usage) effects
+            , Member (Error (ProofError (Annotated usage))) sig
+            , Member Fresh sig
+            , Member (Reader usage) sig
+            , Member (Reader (Context (Constraint (Annotated usage) (Type (Annotated usage))))) sig
+            , Member (State (Substitution (Type (Annotated usage)))) sig
+            , Member (Unify usage) sig
             , Monoid usage
-            , PureEffects effects
+            , Carrier sig m
             , Unital usage
             )
-         => Proof usage (Check usage ': effects) a
-         -> Proof usage effects a
-runCheck = go . lowerEff
-  where go (Return a) = pure a
-        go (Effect (Check term expected) k) = runCheck $ case (unTerm term, unType expected) of
-          (Intro (Abs var body), IntroT (Annotated name pi ::: _S :-> _T))
-            | _S == typeT -> do
-              check term _T >>= Proof . k
-            | otherwise -> do
-              sigma <- ask
-              _T' <- Annotated var (sigma >< pi) ::: _S >- check body _T
-              Proof (k (Annotated name pi ::: _S .-> _T'))
-          (Elim (Case subject matches), _) -> do
-            subject' <- infer subject
-            foldl' (checkMatch subject') (pure expected) matches >>= Proof . k
-          _ -> do
-            actual <- infer term
-            unify actual expected >>= Proof . k
-          where checkMatch subject expected (pattern, body) = do
-                  expected' <- expected
-                  checkPattern pattern subject (check body expected')
-        go (Effect (Infer term) k) = runCheck $ case unTerm term of
-          Var name -> lookupType name >>= Proof . k
-          Intro (Data name vs) -> do
-            _C <- lookupType name
-            checkFields _C vs >>= Proof . k
-            where checkFields ty                                 []       = pure ty
-                  checkFields (Type (IntroT (_ ::: ty :-> ret))) (v : vs) = check v ty >> checkFields ret vs
-                  checkFields ty                                 _        = do
-                    t1 <- freshName
-                    t2 <- freshName
-                    cannotUnify ty (Annotated t1 zero ::: ty .-> tvar t2)
-          Elim (App f a) -> do
-            n <- I <$> fresh
-            t1 <- freshName
-            t2 <- freshName
-            _ <- check f (Annotated n zero ::: tvar t1 .-> tvar t2)
-            _ <- check a (tvar t1)
-            Proof (k (tvar t2))
-          _ -> noRuleToInferType term >>= Proof . k
-        go (Other u k) = liftHandler runCheck u (Proof . k)
+         => Proof usage (CheckC usage (Proof usage m)) a
+         -> Proof usage m a
+runCheck = runCheckC . interpret . runProof
+
+newtype CheckC usage m a = CheckC { runCheckC :: m a }
+
+instance ( Eq usage
+         , Member (Error (ProofError (Annotated usage))) sig
+         , Member Fresh sig
+         , Member (Reader usage) sig
+         , Member (Reader (Context (Constraint (Annotated usage) (Type (Annotated usage))))) sig
+         , Member (State (Substitution (Type (Annotated usage)))) sig
+         , Member (Unify usage) sig
+         , Monoid usage
+         , Carrier sig m
+         , Unital usage
+         )
+      => Carrier (Check usage :+: sig) (CheckC usage (Proof usage m)) where
+  gen = CheckC . gen
+  alg = algC \/ (CheckC . alg . handlePure runCheckC)
+    where algC (Check term expected k) = CheckC $ case (unTerm term, unType expected) of
+            (Intro (Abs var body), IntroT (Annotated name pi ::: _S :-> _T))
+              | _S == typeT -> do
+                runCheck (check term _T) >>= runCheckC . k
+              | otherwise -> do
+                sigma <- ask
+                _T' <- Annotated var (sigma >< pi) ::: _S >- runCheck (check body _T)
+                runCheckC (k (Annotated name pi ::: _S .-> _T'))
+            (Elim (Case subject matches), _) -> do
+              subject' <- runCheck (infer subject)
+              foldl' (checkMatch subject') (pure expected) matches >>= runCheckC . k
+            _ -> do
+              actual <- runCheck (infer term)
+              unify actual expected >>= runCheckC . k
+            where checkMatch subject expected (pattern, body) = do
+                    expected' <- expected
+                    checkPattern pattern subject (runCheck (check body expected'))
+          algC (Infer term k) = CheckC $ case unTerm term of
+            Var name -> lookupType name >>= runCheckC . k
+            Intro (Data name vs) -> do
+              _C <- lookupType name
+              checkFields _C vs >>= runCheckC . k
+              where checkFields ty                                 []       = pure ty
+                    checkFields (Type (IntroT (_ ::: ty :-> ret))) (v : vs) = runCheck (check v ty) >> checkFields ret vs
+                    checkFields ty                                 _        = do
+                      t1 <- freshName
+                      t2 <- freshName
+                      cannotUnify ty (Annotated t1 zero ::: ty .-> tvar t2)
+            Elim (App f a) -> do
+              n <- I <$> fresh
+              t1 <- freshName
+              t2 <- freshName
+              _ <- runCheck (check f (Annotated n zero ::: tvar t1 .-> tvar t2))
+              _ <- runCheck (check a (tvar t1))
+              runCheckC (k (tvar t2))
+            _ -> noRuleToInferType term >>= runCheckC . k
 
 checkPattern :: ( Eq usage
-                , Member (Exc (Error (Annotated usage))) effects
-                , Member Fresh effects
-                , Member (Reader usage) effects
-                , Member (Reader (Context (Constraint (Annotated usage) (Type (Annotated usage))))) effects
-                , Member (State (Substitution (Type (Annotated usage)))) effects
-                , Member (Unify usage) effects
+                , Member (Error (ProofError (Annotated usage))) sig
+                , Member Fresh sig
+                , Member (Reader usage) sig
+                , Member (Reader (Context (Constraint (Annotated usage) (Type (Annotated usage))))) sig
+                , Member (State (Substitution (Type (Annotated usage)))) sig
+                , Member (Unify usage) sig
+                , Carrier sig m
                 , Monoid usage
                 )
              => Pattern Name
              -> Type (Annotated usage)
-             -> Proof usage effects (Type (Annotated usage))
-             -> Proof usage effects (Type (Annotated usage))
+             -> Proof usage m (Type (Annotated usage))
+             -> Proof usage m (Type (Annotated usage))
 checkPattern (Pattern Wildcard)                    _       = id
 checkPattern (Pattern (Variable name))             subject = (Annotated name zero ::: subject >-)
 checkPattern (Pattern (Constructor name patterns)) subject = \ action -> do
@@ -168,26 +183,29 @@ checkPattern (Pattern (Constructor name patterns)) subject = \ action -> do
         checkPatterns ty                                 _        = const (cannotUnify ty subject)
 
 
-runSubstitution :: Effects effects => Named var => Proof usage (State (Substitution (Type var)) ': effects) (Type var) -> Proof usage effects (Type var)
-runSubstitution = fmap (uncurry apply) . runState lowerBound
+runSubstitution :: (Carrier sig m, Effect sig) => Named var => Proof usage (StateC (Substitution (Type var)) (Proof usage m)) (Type var) -> Proof usage m (Type var)
+runSubstitution = fmap (uncurry apply) . runState lowerBound . runProof
 
-runSigma :: (PureEffects effects, Monoid usage, Unital usage) => Purpose -> Proof usage (Reader usage ': effects) a -> Proof usage effects a
-runSigma Extensional = runReader zero
-runSigma Intensional = runReader one
-
-
-check :: Member (Check usage) effects => Term Name -> Type (Annotated usage) -> Proof usage effects (Type (Annotated usage))
-check term ty = send (Check term ty)
-
-infer :: Member (Check usage) effects => Term Name -> Proof usage effects (Type (Annotated usage))
-infer term = send (Infer term)
-
-data Check usage (m :: * -> *) result where
-  Check :: Term Name -> Type (Annotated usage) -> Check usage m (Type (Annotated usage))
-  Infer :: Term Name                           -> Check usage m (Type (Annotated usage))
+runSigma :: (Carrier sig m, Monoid usage, Unital usage) => Purpose -> Proof usage (ReaderC usage (Proof usage m)) a -> Proof usage m a
+runSigma Extensional = runReader zero . runProof
+runSigma Intensional = runReader one  . runProof
 
 
-instance PureEffect (Check usage)
+check :: (Member (Check usage) sig, Carrier sig m) => Term Name -> Type (Annotated usage) -> Proof usage m (Type (Annotated usage))
+check term ty = send (Check term ty gen)
+
+infer :: (Member (Check usage) sig, Carrier sig m) => Term Name -> Proof usage m (Type (Annotated usage))
+infer term = send (Infer term gen)
+
+data Check usage m k
+  = Check (Term Name) (Type (Annotated usage)) (Type (Annotated usage) -> k)
+  | Infer (Term Name)                          (Type (Annotated usage) -> k)
+  deriving (Functor)
+
+instance HFunctor (Check usage) where
+  hfmap _ (Check tm ty k) = Check tm ty k
+  hfmap _ (Infer tm k) = Infer tm k
+
 instance Effect (Check usage) where
-  handleState c dist (Request (Check term ty) k) = Request (Check term ty) (dist . (<$ c) . k)
-  handleState c dist (Request (Infer term)    k) = Request (Infer term)    (dist . (<$ c) . k)
+  handle state handler (Check term ty k) = Check term ty (handler . (<$ state) . k)
+  handle state handler (Infer term    k) = Infer term    (handler . (<$ state) . k)

--- a/src/Manifold/REPL.hs
+++ b/src/Manifold/REPL.hs
@@ -81,16 +81,6 @@ instance Effect (REPL usage) where
   handle state handler (TypeOf t k) = TypeOf t (handler . (<$ state) . k)
   handle state handler (Eval   t k) = Eval   t (handler . (<$ state) . k)
 
--- type ValueSig address sig m
---   =   Env address
---   :+: Allocator address (Value address (ValueC address m))
---   :+: State (Store address (Value address (ValueC address m)))
---   :+: Fresh
---   :+: Resumable (EnvError address)
---   :+: Resumable (StoreError address (Value address (ValueC address m)))
---   :+: Resumable (ValueError address (ValueC address m))
---   :+: sig
-
 newtype ValueC m a
   = ValueC (Evaluator Precise (Value Precise (ValueC m)) (Precise.EnvC
            (Evaluator Precise (Value Precise (ValueC m)) (ReaderC (Environment Precise)

--- a/src/Manifold/REPL.hs
+++ b/src/Manifold/REPL.hs
@@ -1,23 +1,19 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, GADTs, KindSignatures, LambdaCase, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, PolyKinds, TypeOperators, UndecidableInstances #-}
 module Manifold.REPL where
 
 import Control.Applicative (Alternative(..))
-import Control.Monad.Effect
-import Control.Monad.Effect.Fresh
-import Control.Monad.Effect.Reader
-import Control.Monad.Effect.Resumable
+import Control.Effect
 import Data.Functor (($>))
 import Data.Semilattice.Lower
 import Data.Semiring
-import GHC.Generics ((:+:)(..))
-import Manifold.Abstract.Address.Precise as Precise (Precise, runAllocator, runEnv)
-import Manifold.Abstract.Env (Env, EnvError)
+import qualified GHC.Generics as G
+import Manifold.Abstract.Address.Precise as Precise (AllocatorC, EnvC, Precise, runAllocator, runEnv)
+import Manifold.Abstract.Env (Environment, EnvError)
 import Manifold.Abstract.Evaluator (Evaluator(..))
-import Manifold.Abstract.Store (Allocator, Store, StoreError, runStore)
-import qualified Manifold.Abstract.Value as Abstract
+import Manifold.Abstract.Store (Store, StoreError, runStore)
 import Manifold.Constraint
 import Manifold.Context
-import Manifold.Eval (Eval, eval, runEval)
+import Manifold.Eval (EvalC, eval, runEval)
 import Manifold.Name
 import Manifold.Name.Annotated
 import Manifold.Parser as Parser
@@ -31,125 +27,150 @@ import Manifold.Term
 import Manifold.Type
 import Manifold.Unification
 import Manifold.Value as Value
+import System.Console.Haskeline (InputT)
 import Text.Trifecta as Trifecta
 
-repl :: (Member Prompt effects, Member (REPL usage) effects, Monoid usage, Pretty usage) => Proof usage effects ()
+repl :: (Member Prompt sig, Member (REPL usage) sig, Monoid usage, Pretty usage, Carrier sig m) => Proof usage m ()
 repl = prompt >>= maybe repl handleInput
 
-handleInput :: (Member Prompt effects, Member (REPL usage) effects, Monoid usage, Pretty usage) => String -> Proof usage effects ()
+handleInput :: (Member Prompt sig, Member (REPL usage) sig, Monoid usage, Pretty usage, Carrier sig m) => String -> Proof usage m ()
 handleInput str = case Parser.parseString command str of
   Left err -> output err *> repl
   Right action -> action
 
-command :: (Member Prompt effects, Member (REPL usage) effects, Monoid usage, Pretty usage) => Parser.Parser (Proof usage effects ())
+command :: (Member Prompt sig, Member (REPL usage) sig, Monoid usage, Pretty usage, Carrier sig m) => Parser.Parser (Proof usage m ())
 command = whole (meta <|> eval <$> term) <?> "command"
   where meta = colon
-          *> ((long "help" <|> short 'h' <|> short '?' <?> "help") $> (sendREPL Help *> repl)
+          *> ((long "help" <|> short 'h' <|> short '?' <?> "help") $> (sendREPL (Help (gen ())) *> repl)
           <|> (long "quit" <|> short 'q' <?> "quit") $> pure ()
           <|> (typeOf <$> ((long "type" <|> short 't') *> term) <?> "type of")
           <?> "command; use :? for help")
-        eval term = sendREPL (Eval term) >>= output . either prettyShow (either prettyShow prettyShow) >> repl
-        typeOf term = sendREPL (TypeOf term) >>= output . either prettyShow prettyShow >> repl
+        eval term = sendREPL (Eval term gen) >>= output . either prettyShow (either prettyShow prettyShow) >> repl
+        typeOf term = sendREPL (TypeOf term gen) >>= output . either prettyShow prettyShow >> repl
 
         short = symbol . (:[])
         long = symbol
 
 
-sendREPL :: Member (REPL usage) effects => REPL usage (Eff effects) result -> Proof usage effects result
+sendREPL :: (Member (REPL usage) sig, Carrier sig m) => REPL usage (Proof usage m) (Proof usage m result) -> Proof usage m result
 sendREPL = send
 
-data REPL usage (m :: * -> *) result where
-  Help :: REPL usage m ()
-  TypeOf :: Term Name -> REPL usage m (Either (Error (Annotated usage)) (Type (Annotated usage)))
-  Eval :: Term Name -> REPL usage m (Either
-    (Error (Annotated usage))
+data REPL usage m k
+  = Help k
+  | TypeOf (Term Name) (Either (ProofError (Annotated usage)) (Type (Annotated usage)) -> k)
+  | Eval
+    (Term Name)
     (Either
-      (SomeExc
-        (   EnvError Precise
-        :+: StoreError Precise (Value Precise (ValueEff Precise '[]))
-        :+: ValueError Precise (ValueEff Precise '[])))
-      (Value Precise (ValueEff Precise '[]))))
+      (ProofError (Annotated usage))
+      (Either
+        (SomeError
+          (     EnvError Precise
+          G.:+: StoreError Precise (Value Precise (ValueC (Eff VoidC)))
+          G.:+: ValueError Precise (ValueC (Eff VoidC))))
+        (Value Precise (ValueC (Eff VoidC))))
+    -> k)
+  deriving (Functor)
 
-instance PureEffect (REPL usage)
+instance HFunctor (REPL usage) where
+  hfmap _ (Help      k) = Help k
+  hfmap _ (TypeOf tm k) = TypeOf tm k
+  hfmap _ (Eval   tm k) = Eval tm k
+
 instance Effect (REPL usage) where
-  handleState c dist (Request Help k) = Request Help (dist . (<$ c) . k)
-  handleState c dist (Request (TypeOf t) k) = Request (TypeOf t) (dist . (<$ c) . k)
-  handleState c dist (Request (Eval t) k) = Request (Eval t) (dist . (<$ c) . k)
+  handle state handler (Help     k) = Help     (handler . (<$ state) $ k)
+  handle state handler (TypeOf t k) = TypeOf t (handler . (<$ state) . k)
+  handle state handler (Eval   t k) = Eval   t (handler . (<$ state) . k)
 
-newtype ValueEff address effects a
-  = ValueEff (Eff (  Env address
-                  ': Allocator address (Value address (ValueEff address effects))
-                  ': State (Store address (Value address (ValueEff address effects)))
-                  ': Fresh
-                  ': Resumable (EnvError address)
-                  ': Resumable (StoreError address (Value address (ValueEff address effects)))
-                  ': Resumable (ValueError address (ValueEff address effects))
-                  ': effects) a)
+-- type ValueSig address sig m
+--   =   Env address
+--   :+: Allocator address (Value address (ValueC address m))
+--   :+: State (Store address (Value address (ValueC address m)))
+--   :+: Fresh
+--   :+: Resumable (EnvError address)
+--   :+: Resumable (StoreError address (Value address (ValueC address m)))
+--   :+: Resumable (ValueError address (ValueC address m))
+--   :+: sig
+
+newtype ValueC m a
+  = ValueC (Evaluator Precise (Value Precise (ValueC m)) (Precise.EnvC
+           (Evaluator Precise (Value Precise (ValueC m)) (ReaderC (Environment Precise)
+           (Evaluator Precise (Value Precise (ValueC m)) (Precise.AllocatorC
+           (Evaluator Precise (Value Precise (ValueC m)) (StateC (Store Precise (Value Precise (ValueC m)))
+           (Evaluator Precise (Value Precise (ValueC m)) (FreshC
+           (Evaluator Precise (Value Precise (ValueC m)) (ResumableC (EnvError Precise)
+           (Evaluator Precise (Value Precise (ValueC m)) (ResumableC (StoreError Precise (Value Precise (ValueC m)))
+           (Evaluator Precise (Value Precise (ValueC m)) (ResumableC (ValueError Precise (ValueC m))
+            m))))))))))))))) a)
 
 type Prelude var = Context (Constraint var (Type var))
 
-runREPL :: (Effects effects, Eq usage, Member Prompt effects, Monoid usage, Unital usage) => Prelude (Annotated usage) -> Proof usage (REPL usage ': effects) a -> Proof usage effects a
-runREPL prelude = interpret $ \case
-  Help -> output (unlines
-    [ ":help, :h, :?     - print this help text"
-    , ":quit, :q         - exit the REPL"
-    , ":type, :t <expr>  - print the type of <expr>"
-    , "<expr>            - typecheck & evaluate <expr>"
-    ])
-  TypeOf term -> runCheck' Intensional (local (const prelude) (infer term))
-  Eval term -> do
-    res <- runCheck' Intensional (local (const prelude) (infer term))
-    case res of
-      Left err -> pure (Left err)
-      _        -> pure (Right (run (runEvaluator (runEval' (eval term)))))
+runREPL :: (Eq usage, Member Prompt sig, Monoid usage, Unital usage, Carrier sig m, Effect sig) => Prelude (Annotated usage) -> Proof usage (REPLC usage (Proof usage m)) a -> Proof usage m a
+runREPL prelude = flip runREPLC prelude . interpret . runProof
 
+newtype REPLC usage m a = REPLC { runREPLC :: Prelude (Annotated usage) -> m a }
 
-runCheck' :: ( Effects effects
+instance (Eq usage, Member Prompt sig, Carrier sig m, Monoid usage, Unital usage, Effect sig) => Carrier (REPL usage :+: sig) (REPLC usage (Proof usage m)) where
+  gen a = REPLC (\ _ -> pure a)
+  alg = algR \/ algOther
+    where algR (Help k) = REPLC (\ prelude -> output (unlines
+            [ ":help, :h, :?     - print this help text"
+            , ":quit, :q         - exit the REPL"
+            , ":type, :t <expr>  - print the type of <expr>"
+            , "<expr>            - typecheck & evaluate <expr>"
+            ]) >> runREPLC k prelude)
+          algR (TypeOf term k) = REPLC (\ prelude -> runCheck' Intensional (local (const prelude) (infer term)) >>= flip runREPLC prelude . k)
+          algR (Eval term k) = REPLC (\ prelude -> do
+            res <- runCheck' Intensional (local (const prelude) (infer term))
+            case res of
+              Left err -> runREPLC (k (Left err)) prelude
+              _        -> runREPLC (k (Right (run (runEval' (eval term))))) prelude)
+          algOther op = REPLC (\ prelude -> alg (handlePure (flip runREPLC prelude) op))
+
+runCheck' :: ( Effectful sig m'
              , Eq usage
              , Monoid usage
              , Unital usage
              )
           => Purpose
-          -> Proof usage
-            (  Check usage
-            ': Unify usage
-            ': Reader (Context (Constraint (Annotated usage) (Type (Annotated usage))))
-            ': Reader usage
-            ': Fresh
-            ': State (Substitution (Type (Annotated usage)))
-            ': Exc (Error (Annotated usage))
-            ': effects) (Type (Annotated usage))
-          -> Proof usage effects
+          -> Proof usage (CheckC usage
+            (Proof usage (UnifyC usage
+            (Proof usage (ReaderC (Context (Constraint (Annotated usage) (Type (Annotated usage))))
+            (Proof usage (ReaderC usage
+            (Proof usage (FreshC
+            (Proof usage (StateC (Substitution (Type (Annotated usage)))
+            (Proof usage (ErrorC (ProofError (Annotated usage))
+            m'))))))))))))) (Type (Annotated usage))
+          -> m'
             (Either
-              (Error (Annotated usage))
+              (ProofError (Annotated usage))
               (Type (Annotated usage)))
-runCheck' purpose = runError . runSubstitution . runFresh 0 . runSigma purpose . runContext . runUnify . runCheck
+runCheck' purpose = runError . runProof . runSubstitution . runFresh . runProof . runSigma purpose . runContext . runUnify . runCheck
 
-runEval' :: Effects effects
-         => Evaluator Precise (Value Precise (ValueEff Precise effects))
-           (  Eval (Value Precise (ValueEff Precise effects))
-           ': Abstract.Data (Value Precise (ValueEff Precise effects))
-           ': Abstract.Function (Value Precise (ValueEff Precise effects))
-           ': Env Precise
-           ': Allocator Precise (Value Precise (ValueEff Precise effects))
-           ': State (Store Precise (Value Precise (ValueEff Precise effects)))
-           ': Fresh
-           ': Resumable (EnvError Precise)
-           ': Resumable (StoreError Precise (Value Precise (ValueEff Precise effects)))
-           ': Resumable (ValueError Precise (ValueEff Precise effects))
-           ': effects) a
-         -> Evaluator Precise (Value Precise (ValueEff Precise effects)) effects
+runEval' :: Effectful sig m
+         => Evaluator Precise (Value Precise (ValueC m)) (EvalC
+           (Evaluator Precise (Value Precise (ValueC m)) (Value.DataC
+           (Evaluator Precise (Value Precise (ValueC m)) (Value.FunctionC
+           (Evaluator Precise (Value Precise (ValueC m)) (Precise.EnvC
+           (Evaluator Precise (Value Precise (ValueC m)) (ReaderC (Environment Precise)
+           (Evaluator Precise (Value Precise (ValueC m)) (Precise.AllocatorC
+           (Evaluator Precise (Value Precise (ValueC m)) (StateC (Store Precise (Value Precise (ValueC m)))
+           (Evaluator Precise (Value Precise (ValueC m)) (FreshC
+           (Evaluator Precise (Value Precise (ValueC m)) (ResumableC (EnvError Precise)
+           (Evaluator Precise (Value Precise (ValueC m)) (ResumableC (StoreError Precise (Value Precise (ValueC m)))
+           (Evaluator Precise (Value Precise (ValueC m)) (ResumableC (ValueError Precise (ValueC m))
+            m))))))))))))))))))))) a
+         -> m
            (Either
-             (SomeExc
-               (   EnvError Precise
-               :+: StoreError Precise (Value Precise (ValueEff Precise effects))
-               :+: ValueError Precise (ValueEff Precise effects)))
+             (SomeError
+               (     EnvError Precise
+               G.:+: StoreError Precise (Value Precise (ValueC m))
+               G.:+: ValueError Precise (ValueC m)))
              a)
-runEval' = fmap (merge . merge) . runResumable . runResumable . runResumable . runFresh 0 . fmap snd . runStore . Precise.runAllocator . runReader lowerBound . Precise.runEnv . Value.runFunction . Value.runData . runEval
-  where merge :: Either (SomeExc sum) (Either (SomeExc exc) a) -> Either (SomeExc (exc :+: sum)) a
-        merge (Left (SomeExc exc)) = Left (SomeExc (R1 exc))
-        merge (Right (Left (SomeExc exc))) = Left (SomeExc (L1 exc))
+runEval' = fmap (merge . merge) . runResumable . runEvaluator . runResumable . runEvaluator . runResumable . runEvaluator . runFresh . runEvaluator . fmap snd . runStore . Precise.runAllocator . runReader lowerBound . runEvaluator . Precise.runEnv . Value.runFunction . Value.runData . runEval
+  where merge :: Either (SomeError sum) (Either (SomeError exc) a) -> Either (SomeError (exc G.:+: sum)) a
+        merge (Left (SomeError exc)) = Left (SomeError (G.R1 exc))
+        merge (Right (Left (SomeError exc))) = Left (SomeError (G.L1 exc))
         merge (Right (Right a)) = Right a
 
-runIO :: (Eq usage, Monoid usage, Unital usage) => Prelude (Annotated usage) -> Proof usage '[REPL usage, Prompt] a -> IO a
-runIO prelude = runPrompt "λ: " . runREPL prelude
+runIO :: (Eq usage, Monoid usage, Unital usage) => Prelude (Annotated usage) -> Proof usage (REPLC usage (Proof usage (PromptC (Eff (LiftC (InputT IO)))))) a -> IO a
+runIO prelude = runPrompt "λ: " . runProof . runREPL prelude

--- a/src/Manifold/Unification.hs
+++ b/src/Manifold/Unification.hs
@@ -1,10 +1,7 @@
-{-# LANGUAGE DataKinds, FlexibleContexts, GADTs, KindSignatures, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, PolyKinds, TypeOperators, UndecidableInstances #-}
 module Manifold.Unification where
 
-import Control.Monad.Effect
-import Control.Monad.Effect.Fresh
-import Control.Monad.Effect.Internal hiding (apply)
-import Control.Monad.Effect.State
+import Control.Effect
 import Manifold.Constraint
 import Manifold.Context
 import Manifold.Name
@@ -17,63 +14,77 @@ import Manifold.Type
 import Manifold.Type.Intro
 
 runUnify :: ( Eq usage
-            , Member (Exc (Error (Annotated usage))) effects
-            , Member Fresh effects
-            , Member (Reader (Context (Constraint (Annotated usage) (Type (Annotated usage))))) effects
-            , Member (State (Substitution (Type (Annotated usage)))) effects
-            , PureEffects effects
+            , Member (Error (ProofError (Annotated usage))) sig
+            , Member Fresh sig
+            , Member (Reader (Context (Constraint (Annotated usage) (Type (Annotated usage))))) sig
+            , Member (State (Substitution (Type (Annotated usage)))) sig
+            , Carrier sig m
             )
-         => Proof usage (Unify usage ': effects) a
-         -> Proof usage effects a
-runUnify = go . lowerEff
-  where go (Return a) = pure a
-        go (Effect (Unify t1 t2) k)
-          | t1 == t2  = runUnify $ Proof (k t2)
-          | otherwise = runUnify $ case (unType t1, unType t2) of
-            (Var n1, _)          -> n1 >-> t2 *> Proof (k t2)
-            (_, Var n2)          -> n2 >-> t1 *> Proof (k t1)
-            (Intro i1, Intro i2)
-              | Abs (v1 ::: t1) b1 <- i1
-              , Abs (v2 ::: t2) b2 <- i2 -> do
-                n' <- I <$> fresh
-                t' <- unify t1 t2
-                b' <- unify (apply (singletonSubst (name v1) (tvar n')) b1)
-                            (apply (singletonSubst (name v2) (tvar n')) b2)
-                Proof (k (tintro (Abs (setName n' v1 ::: t') b')))
-              | Data n1 ts1 <- i1
-              , Data n2 ts2 <- i2
-              , n1 == n2
-              , length ts1 == length ts2 -> tintro . Data n2 <$> sequenceA (zipWith unify ts1 ts2) >>= Proof . k
-            (IntroT i1, IntroT i2)
-              | TypeT <- i1, TypeT <- i2 -> Proof (k typeT)
-              | TypeC n1 ts1 <- i1
-              , TypeC n2 ts2 <- i2
-              , n1 == n2
-              , length ts1 == length ts2 -> typeC n2 <$> sequenceA (zipWith unify ts1 ts2) >>= Proof . k
-              | v1 ::: t1 :-> b1 <- i1
-              , v2 ::: t2 :-> b2 <- i2 -> do
-                n' <- I <$> fresh
-                t' <- unify t1 t2
-                b' <- unify (apply (singletonSubst (name v1) (tvar n')) b1)
-                            (apply (singletonSubst (name v2) (tvar n')) b2)
-                Proof (k (setName n' v1 ::: t' .-> b'))
-              | a1 :* b1 <- i1, a2 :* b2 <- i2 -> (.*) <$> unify a1 a2 <*> unify b1 b2 >>= Proof . k
-            (Elim e1, Elim e2)
-              | App f1 a1   <- e1, App f2 a2   <- e2 -> fmap telim . App <$> unify f1 f2 <*> unify a1 a2 >>= Proof . k
-            _                                        -> cannotUnify t1 t2
-        go (Other u k) = liftHandler runUnify u (Proof . k)
+         => Proof usage (UnifyC usage (Proof usage m)) a
+         -> Proof usage m a
+runUnify = runUnifyC . interpret . runProof
+
+newtype UnifyC usage m a = UnifyC { runUnifyC :: m a }
+
+instance ( Eq usage
+         , Member (Error (ProofError (Annotated usage))) sig
+         , Member Fresh sig
+         , Member (Reader (Context (Constraint (Annotated usage) (Type (Annotated usage))))) sig
+         , Member (State (Substitution (Type (Annotated usage)))) sig
+         , Carrier sig m
+         )
+      => Carrier (Unify usage :+: sig) (UnifyC usage (Proof usage m)) where
+  gen = UnifyC . gen
+  alg = algU \/ (UnifyC . alg . handlePure runUnifyC)
+    where algU (Unify t1 t2 k)
+            | t1 == t2  = k t2
+            | otherwise = UnifyC $ case (unType t1, unType t2) of
+              (Var n1, _)          -> n1 >-> t2 *> runUnifyC (k t2)
+              (_, Var n2)          -> n2 >-> t1 *> runUnifyC (k t1)
+              (Intro i1, Intro i2)
+                | Abs (v1 ::: t1) b1 <- i1
+                , Abs (v2 ::: t2) b2 <- i2 -> do
+                  n' <- I <$> fresh
+                  t' <- runUnify (unify t1 t2)
+                  b' <- runUnify (unify (apply (singletonSubst (name v1) (tvar n')) b1)
+                                        (apply (singletonSubst (name v2) (tvar n')) b2))
+                  runUnifyC (k (tintro (Abs (setName n' v1 ::: t') b')))
+                | Data n1 ts1 <- i1
+                , Data n2 ts2 <- i2
+                , n1 == n2
+                , length ts1 == length ts2 -> runUnify (tintro . Data n2 <$> sequenceA (zipWith unify ts1 ts2)) >>= runUnifyC . k
+              (IntroT i1, IntroT i2)
+                | TypeT <- i1, TypeT <- i2 -> runUnifyC (k typeT)
+                | TypeC n1 ts1 <- i1
+                , TypeC n2 ts2 <- i2
+                , n1 == n2
+                , length ts1 == length ts2 -> runUnify (typeC n2 <$> sequenceA (zipWith unify ts1 ts2)) >>= runUnifyC . k
+                | v1 ::: t1 :-> b1 <- i1
+                , v2 ::: t2 :-> b2 <- i2 -> do
+                  n' <- I <$> fresh
+                  t' <- runUnify (unify t1 t2)
+                  b' <- runUnify (unify (apply (singletonSubst (name v1) (tvar n')) b1)
+                                        (apply (singletonSubst (name v2) (tvar n')) b2))
+                  runUnifyC (k (setName n' v1 ::: t' .-> b'))
+                | a1 :* b1 <- i1, a2 :* b2 <- i2 -> runUnify ((.*) <$> unify a1 a2 <*> unify b1 b2) >>= runUnifyC . k
+              (Elim e1, Elim e2)
+                | App f1 a1   <- e1, App f2 a2   <- e2 -> runUnify (fmap telim . App <$> unify f1 f2 <*> unify a1 a2) >>= runUnifyC . k
+              _                                        -> cannotUnify t1 t2
 
 
-(>->) :: (Member (State (Substitution (Type (Annotated usage)))) effects, Named (Annotated usage)) => Name -> Type (Annotated usage) -> Proof usage effects ()
-name >-> sub = modify' (<> singletonSubst name sub)
+(>->) :: (Member (State (Substitution (Type (Annotated usage)))) sig, Carrier sig m) => Name -> Type (Annotated usage) -> Proof usage m ()
+name >-> sub = modify (<> singletonSubst name sub)
 
 
-unify :: Member (Unify usage) effects => Type (Annotated usage) -> Type (Annotated usage) -> Proof usage effects (Type (Annotated usage))
-unify t1 t2 = send (Unify t1 t2)
+unify :: (Member (Unify usage) sig, Carrier sig m) => Type (Annotated usage) -> Type (Annotated usage) -> Proof usage m (Type (Annotated usage))
+unify t1 t2 = send (Unify t1 t2 gen)
 
-data Unify usage (m :: * -> *) result where
-  Unify :: Type (Annotated usage) -> Type (Annotated usage) -> Unify usage m (Type (Annotated usage))
+data Unify usage m k
+  = Unify (Type (Annotated usage)) (Type (Annotated usage)) (Type (Annotated usage) -> k)
+  deriving (Functor)
 
-instance PureEffect (Unify usage)
+instance HFunctor (Unify usage) where
+  hfmap _ (Unify t1 t2 k) = Unify t1 t2 k
+
 instance Effect (Unify usage) where
-  handleState c dist (Request (Unify t1 t2) k) = Request (Unify t1 t2) (dist . (<$ c) . k)
+  handle state handler (Unify t1 t2 k) = Unify t1 t2 (handler . (<$ state) . k)


### PR DESCRIPTION
This PR ports everything over from https://github.com/joshvera/effects to https://github.com/robrix/higher-order-effects.

Handlers are now specified as functions + `newtype`s with `Carrier` instances implementing an algebra, which makes some of them longer than they were since the context has to be duplicated in both the function and the `Carrier` instance.

`HFunctor` instances currently have to be hand-written; it’d be nice if we could derive them instead. Maybe we can write a `GHC.Generics` derivation, or maybe we can wait for `DerivingVia` and/or derive `HFunctor` from `Effect` (tho then again maybe not—@rewinfrey & I had trouble implementing `hfmap` in terms of `handle` due to the latter’s action on the continuation positions in addition to the higher-order positions).

There were a couple of cases where `PolyKinds` inferred too general a kind for some phantom parameters, resulting in bizarre and hard-to-debug type errors in effect handlers. We might be able to rule that out by restricting some of the kinds in `higher-order-effects`, I’m honestly not certain.

Writing handlers as `Carrier` instances is ok, but given `alg = algHere \/ algThere`, type errors in `algHere` (which are far likelier) tend to be obscured by spurious type errors in `algThere`—i.e. the typechecking algorithm is reporting errors in the wrong position. It might help if we had some sensible defaults for the `Foo . alg . handlePure runFoo` pattern on the right, or if we simply provided a composed or even just flipped version of `\/` (which would lend itself to writing handlers using `-XLambdaCase`, which would itself be pleasant).

Specifying composite handlers looks really funny since you mention deeply nested `Evaluator`s/carriers instead of the effects being handled—see `Manifold.REPL` for examples of this. This is a consequence of fusion—in essence it’s a sign that things are working as intended, just a little surprising if you weren’t otherwise expecting it.

`Effect` instances are virtually unchanged, other than being a bit tidier due to the removal of `Request`. I’m pretty happy with how they turned out.

Curiously, assuming the presence of `Evaluator`s in the body of various effects means that carriers don’t need to duplicate the phantom type parameters that `Evaluator` provides. E.g. `Precise.AllocatorC` doesn’t need a `value` type parameter even tho it’s a carrier for `Allocator Precise value`.

All in all I think this was pretty successful!